### PR TITLE
Modify compute instance name

### DIFF
--- a/.github/workflows/00-stop-compute-instance.yml
+++ b/.github/workflows/00-stop-compute-instance.yml
@@ -16,7 +16,7 @@ on:
       compute:
         description: 'Azure Machine Learning compute instance name'
         required: true
-        default: 'dev-vm-1' 
+        default: 'dev-vm' 
         type: string
 
 jobs:


### PR DESCRIPTION
I get the following error when creating a computing instance. This is because the naming rules do not allow it.
> Compute name must not end with '-' or contain '-' followed by numbers. '-' needs to be followed by at least one letter

I would recommend aligning to the yaml for job.
Please let me know if I am wrong....
![image](https://user-images.githubusercontent.com/11484713/179958159-91edc29d-aef5-4b0d-b3c0-ec2164fdec37.png)
