### PR TITLE
fixed file name diabetes.csv to diabetes-dev.csv

### DIFF
--- a/experimentation/train-classification-model.ipynb
+++ b/experimentation/train-classification-model.ipynb
@@ -34,7 +34,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "df = pd.read_csv('data/diabetes.csv')"
+        "df = pd.read_csv('data/diabetes-dev.csv')"
       ]
     },
     {


### PR DESCRIPTION
The template contains wrong file name to read the diabetes data, which leads to filname Not Found Error.

Changes made:
data/diabetes.csv -> data/diabetes-dev.csv